### PR TITLE
Exclude namespaces value should be formed in array

### DIFF
--- a/docs/log-routing.md
+++ b/docs/log-routing.md
@@ -47,12 +47,12 @@ ClusterFlow:
       - exclude:
           labels:
             exclude-this: label
-          namespaces: developer 
+          namespaces: [developer] 
       - select:
           labels:
             app: nginx
             label/xxx: example
-          namespaces: production,beta
+          namespaces: [production,beta]
 ```
 
 ## Examples
@@ -131,7 +131,7 @@ Exclude cluster logs from  `dev`, `sandbox` namespaces and select `app: nginx` f
       - forward-output-sample
     match:
       - exclude:
-          namespaces: dev,sandbox
+          namespaces: [dev,sandbox]
       - select:
           labels:
             app: nginx
@@ -151,9 +151,9 @@ Exclude cluster logs from  `dev`, `sandbox` namespaces and select `app: nginx` f
       - forward-output-sample
     match:
       - exclude:
-          namespaces: dev,sandbox
+          namespaces: [dev,sandbox]
       - select:
           labels:
             app: nginx
-          namespaces: prod,infra
+          namespaces: [prod,infra]
   ```


### PR DESCRIPTION
Test on my local env, if I use just comma seperated string in namespaces in match.exclue and match.select, The form error is generated.